### PR TITLE
chore: Disable automatic startup of services

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+samba (2:4.19.5+dfsg-1deepin3) unstable; urgency=medium
+
+  * update debian/rules to disable services.
+
+ -- wangrong <wangrong@uniontech.com>  Mon, 19 May 2025 20:36:32 +0800
+
 samba (2:4.19.5+dfsg-1deepin2) unstable; urgency=medium
 
   * fix mips filesize is zero.

--- a/debian/rules
+++ b/debian/rules
@@ -298,11 +298,12 @@ override_dh_installpam:
 ifpkg = $(if $(filter ${1},${build-pkgs}),${2})
 
 override_dh_installinit:
-ifneq (,$(filter samba, ${build-pkgs}))
-	dh_installinit -psamba --name smbd
-	dh_installinit -psamba --name nmbd --error-handler nmbd_error_handler
-	dh_installinit -psamba --name samba-ad-dc
-endif
+	# Disable smbd nmbd samba-ad-dc auto-start
+# ifneq (,$(filter samba, ${build-pkgs}))
+# 	dh_installinit -psamba --name smbd
+# 	dh_installinit -psamba --name nmbd --error-handler nmbd_error_handler
+# 	dh_installinit -psamba --name samba-ad-dc
+# endif
 	$(call ifpkg, winbind, dh_installinit -pwinbind)
 ifneq (,$(filter ctdb, ${build-pkgs}))
 	install -Dp -m755 ctdb/config/ctdb.init debian/ctdb/etc/init.d/ctdb
@@ -311,11 +312,12 @@ ifneq (,$(filter ctdb, ${build-pkgs}))
 endif
 
 override_dh_installsystemd:
-ifneq (,$(filter samba, ${build-pkgs}))
-	dh_installsystemd -psamba --name=smbd
-	dh_installsystemd -psamba --name=nmbd
-	dh_installsystemd -psamba --name=samba-ad-dc
-endif
+	# Disable smbd nmbd samba-ad-dc auto-start
+# ifneq (,$(filter samba, ${build-pkgs}))
+# 	dh_installsystemd -psamba --name=smbd
+# 	dh_installsystemd -psamba --name=nmbd
+# 	dh_installsystemd -psamba --name=samba-ad-dc
+# endif
 	$(call ifpkg, winbind, dh_installsystemd -pwinbind)
 	$(call ifpkg, ctdb, dh_installsystemd -pctdb --no-start --no-stop-on-upgrade)
 


### PR DESCRIPTION
Disable smbd nmbd samba-ad-dc auto-start.

Log: Disable automatic startup of services
Task: https://pms.uniontech.com/task-view-376765.html