### PR TITLE
fix: fix CVE-2025-10230 WINS hook shell command injection vulnerability

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+samba (2:4.19.5+dfsg-1deepin5) unstable; urgency=high
+
+  * Fix CVE-2025-10230: WINS hook shell command injection vulnerability
+    - Add validation for WINS names before passing to wins hook script
+    - Prevent arbitrary command execution through malicious NetBIOS names
+    - Restrict valid characters to letters, digits, hyphens, underscores and periods
+    - Add test cases to verify the fix
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 19 Mar 2026 21:09:19 +0800
+
+
 samba (2:4.19.5+dfsg-1deepin4) unstable; urgency=medium
 
   * fix missing systemd .service files.

--- a/debian/patches/CVE-2025-10230-fix.patch
+++ b/debian/patches/CVE-2025-10230-fix.patch
@@ -1,0 +1,72 @@
+From cec06776e4db805e9a8d1f2428f88895f3bf79a0 Mon Sep 17 00:00:00 2001
+From: Douglas Bagnall <douglas.bagnall@catalyst.net.nz>
+Date: Wed, 3 Sep 2025 14:20:24 +1200
+Subject: [PATCH 2/2] CVE-2025-10230: s4:wins: restrict names fed to shell
+
+If the "wins hook" smb.conf parameter is set, the WINS server will
+attempt to execute that value in a shell command line when a client
+asks to modify a name. The WINS system is a trusting one, and clients
+can claim any NETBIOS name they wish.
+
+With the source3 nmbd WINS server (since the 1999 commit now called
+3db52feb1f3b2c07ce0b06ad4a7099fa6efe3fc7) the wins hook will not be
+run for names that contain shell metacharacters. This restriction has
+not been present on the source4 nbt WINS server, which is the WINS
+server that will be used in the event that an Active Directory Domain
+Controller is also running WINS.
+
+This allowed an unauthenticated client to execute arbitrary commands
+on the server.
+
+This commit brings the nmbd check into the nbt WINS server, so that
+the wins hook will only be run for names that contain only letters,
+digits, hyphens, underscores and periods. This matches the behaviour
+described in the smb.conf man page.
+
+The source3 nmbd WINS server has another layer of protection, in that
+it uses the smb_run() exec wrapper that tries to escape arguments. We
+don't do that here.
+
+BUG: https://bugzilla.samba.org/show_bug.cgi?id=15903
+
+Signed-off-by: Douglas Bagnall <douglas.bagnall@catalyst.net.nz>
+Reviewed-by: Gary Lockyer <gary@catalyst.net.nz>
+---
+ selftest/knownfail.d/samba4.nbt.wins.wins_bad_names | 1 -
+ source4/nbt_server/wins/wins_hook.c                 | 9 +++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+ delete mode 100644 selftest/knownfail.d/samba4.nbt.wins.wins_bad_names
+
+diff --git a/selftest/knownfail.d/samba4.nbt.wins.wins_bad_names b/selftest/knownfail.d/samba4.nbt.wins.wins_bad_names
+deleted file mode 100644
+index 52388ce5749..00000000000
+--- a/selftest/knownfail.d/samba4.nbt.wins.wins_bad_names
++++ /dev/null
+@@ -1 +0,0 @@
+-samba4.nbt.wins.wins_bad_names
+diff --git a/source4/nbt_server/wins/wins_hook.c b/source4/nbt_server/wins/wins_hook.c
+index 1af471b15bc..442141fecdd 100644
+--- a/source4/nbt_server/wins/wins_hook.c
++++ b/source4/nbt_server/wins/wins_hook.c
+@@ -43,9 +43,18 @@ void wins_hook(struct winsdb_handle *h, const struct winsdb_record *rec,
+ 	int child;
+ 	char *cmd = NULL;
+ 	TALLOC_CTX *tmp_mem = NULL;
++	const char *p = NULL;
+ 
+ 	if (!wins_hook_script || !wins_hook_script[0]) return;
+ 
++	for (p = rec->name->name; *p; p++) {
++		if (!(isalnum((int)*p) || strchr_m("._-", *p))) {
++			DBG_ERR("not calling wins hook for invalid name %s\n",
++				rec->name->name);
++			return;
++		}
++	}
++
+ 	tmp_mem = talloc_new(h);
+ 	if (!tmp_mem) goto failed;
+ 
+-- 
+2.43.0
+

--- a/debian/patches/CVE-2025-10230-tests.patch
+++ b/debian/patches/CVE-2025-10230-tests.patch
@@ -1,0 +1,273 @@
+From b1b1a8235f52160cf9a02ad92b346084c48095fc Mon Sep 17 00:00:00 2001
+From: Douglas Bagnall <douglas.bagnall@catalyst.net.nz>
+Date: Tue, 9 Sep 2025 13:36:16 +1200
+Subject: [PATCH 1/2] CVE-2025-10230: s4/tests: check that wins hook sanitizes
+ names
+
+An smb.conf can contain a 'wins hook' parameter, which names a script
+to run when a WINS name is changed. The man page says
+
+    The second argument is the NetBIOS name. If the name is not a
+    legal name then the wins hook is not called. Legal names contain
+    only letters, digits, hyphens, underscores and periods.
+
+but it turns out the legality check is not performed if the WINS
+server in question is the source4 nbt one. It is not expected that
+people will run this server, but they can. This is bad because the
+name is passed unescaped into a shell command line, allowing command
+injection.
+
+For this test we don't care whether the WINS server is returning an
+error code, just whether it is running the wins hook. The tests show
+it often runs the hook it shouldn't, though some characters are
+incidentally blocked because the name has to fit in a DN before it
+gets to the hook, and DNs have a few syntactic restrictions (e.g.,
+blocking '<', '>', and ';').
+
+The source3 WINS server that is used by Samba when not run as a DC is
+not affected and not here tested.
+
+BUG: https://bugzilla.samba.org/show_bug.cgi?id=15903
+
+Signed-off-by: Douglas Bagnall <douglas.bagnall@catalyst.net.nz>
+Reviewed-by: Gary Lockyer <gary@catalyst.net.nz>
+---
+ python/samba/tests/usage.py                   |   2 +
+ .../samba4.nbt.wins.wins_bad_names            |   1 +
+ selftest/target/Samba4.pm                     |   1 +
+ source4/torture/nbt/wins.c                    | 136 +++++++++++++++++-
+ testprogs/blackbox/wins_hook_test             |  15 ++
+ 5 files changed, 152 insertions(+), 3 deletions(-)
+ create mode 100644 selftest/knownfail.d/samba4.nbt.wins.wins_bad_names
+ create mode 100755 testprogs/blackbox/wins_hook_test
+
+--- a/python/samba/tests/usage.py
++++ b/python/samba/tests/usage.py
+@@ -73,6 +73,7 @@ EXCLUDE_USAGE = {
+     'lib/ldb/tests/python/api.py',
+     'source4/selftest/tests.py',
+     'buildtools/bin/waf',
++    'testprogs/blackbox/wins_hook_test',
+     'selftest/tap2subunit',
+     'script/show_test_time',
+     'source4/scripting/bin/subunitrun',
+@@ -89,6 +90,7 @@ EXCLUDE_HELP = {
+     'selftest/tap2subunit',
+     'wintest/test-s3.py',
+     'wintest/test-s4-howto.py',
++    'testprogs/blackbox/wins_hook_test',
+ }
+ 
+ 
+--- /dev/null
++++ b/selftest/knownfail.d/samba4.nbt.wins.wins_bad_names
+@@ -0,0 +1 @@
++samba4.nbt.wins.wins_bad_names
+--- a/selftest/target/Samba4.pm
++++ b/selftest/target/Samba4.pm
+@@ -1626,6 +1626,7 @@ sub provision_ad_dc_ntvfs($$$)
+ 	ldap server require strong auth = allow_sasl_over_tls
+ 	raw NTLMv2 auth = yes
+ 	lsa over netlogon = yes
++	wins hook = $ENV{SRCDIR_ABS}/testprogs/blackbox/wins_hook_test
+         rpc server port = 1027
+         auth event notification = true
+ 	dsdb event notification = true
+--- a/source4/torture/nbt/wins.c
++++ b/source4/torture/nbt/wins.c
+@@ -31,6 +31,10 @@
+ #include "torture/nbt/proto.h"
+ #include "param/param.h"
+ 
++/* rcode used when you don't want to check the rcode */
++#define WINS_TEST_RCODE_WE_DONT_CARE 255
++
++
+ #define CHECK_VALUE(tctx, v, correct) \
+ 	torture_assert_int_equal(tctx, v, correct, "Incorrect value")
+ 
+@@ -137,7 +141,9 @@ static bool nbt_test_wins_name(struct to
+ 					address));
+ 
+ 		CHECK_STRING(tctx, io.out.wins_server, address);
+-		CHECK_VALUE(tctx, io.out.rcode, 0);
++		if (register_rcode != WINS_TEST_RCODE_WE_DONT_CARE) {
++			CHECK_VALUE(tctx, io.out.rcode, 0);
++		}
+ 
+ 		torture_comment(tctx, "register the name correct address\n");
+ 		name_register.in.name		= *name;
+@@ -185,7 +191,9 @@ static bool nbt_test_wins_name(struct to
+ 			talloc_asprintf(tctx, "Bad response from %s for name register\n",
+ 					address));
+ 
+-		CHECK_VALUE(tctx, name_register.out.rcode, 0);
++		if (register_rcode != WINS_TEST_RCODE_WE_DONT_CARE) {
++			CHECK_VALUE(tctx, name_register.out.rcode, 0);
++		}
+ 		CHECK_STRING(tctx, name_register.out.reply_addr, myaddress);
+ 	}
+ 
+@@ -203,7 +211,9 @@ static bool nbt_test_wins_name(struct to
+ 	torture_assert_ntstatus_ok(tctx, status, talloc_asprintf(tctx, "Bad response from %s for name register", address));
+ 	
+ 	CHECK_STRING(tctx, io.out.wins_server, address);
+-	CHECK_VALUE(tctx, io.out.rcode, register_rcode);
++	if (register_rcode != WINS_TEST_RCODE_WE_DONT_CARE) {
++		CHECK_VALUE(tctx, io.out.rcode, register_rcode);
++	}
+ 
+ 	if (register_rcode != NBT_RCODE_OK) {
+ 		return true;
+@@ -533,6 +543,124 @@ static bool nbt_test_wins(struct torture
+ }
+ 
+ /*
++ * Test that the WINS server does not call 'wins hook' when the name
++ * contains dodgy characters.
++ */
++static bool nbt_test_wins_bad_names(struct torture_context *tctx)
++{
++	const char *address = NULL;
++	const char *wins_hook_file = NULL;
++	bool ret = true;
++	int err;
++	bool ok;
++	struct nbt_name name = {};
++	size_t i, j;
++	FILE *fh = NULL;
++
++	struct {
++		const char *name;
++		bool should_succeed;
++	} test_cases[] = {
++		{"NORMAL", true},
++		{"|look|", false},
++		{"look&true", false},
++		{"look\\;false", false},
++		{"&ls>foo", false},  /* already fails due to DN syntax */
++		{"has spaces", false},
++		{"hyphen-dot.0", true},
++	};
++
++	wins_hook_file = talloc_asprintf(tctx, "%s/wins_hook_writes_here",
++					 getenv("SELFTEST_TMPDIR"));
++
++	if (!torture_nbt_get_name(tctx, &name, &address)) {
++		return false;
++	}
++
++	for (i = 0; i < ARRAY_SIZE(test_cases); i++) {
++		err =  unlink(wins_hook_file);
++		if (err != 0 && errno != ENOENT) {
++			/* we expect ENOENT, but nothing else */
++			torture_comment(tctx,
++					"unlink %zu of '%s' failed\n",
++					i, wins_hook_file);
++		}
++
++		name.name = test_cases[i].name;
++		name.type = NBT_NAME_CLIENT;
++		ok = nbt_test_wins_name(tctx, address,
++					&name,
++					NBT_NODE_H,
++					true,
++					WINS_TEST_RCODE_WE_DONT_CARE
++			);
++		if (ok == false) {
++			/*
++			 * This happens when the name interferes with
++			 * the DN syntax when it is put in winsdb.
++			 *
++			 * The wins hook will not be reached.
++			 */
++			torture_comment(tctx, "tests for '%s' failed\n",
++					name.name);
++		}
++
++		/*
++		 * poll for the file being created by the wins hook.
++		 */
++		for (j = 0; j < 10; j++) {
++			usleep(200000);
++			fh = fopen(wins_hook_file, "r");
++			if (fh != NULL) {
++				break;
++			}
++		}
++
++		if (fh == NULL) {
++			if (errno == ENOENT) {
++				if (test_cases[i].should_succeed) {
++					torture_comment(
++						tctx,
++						"wins hook for '%s' failed\n",
++						test_cases[i].name);
++					ret = false;
++				}
++			} else {
++				torture_comment(
++					tctx,
++					"wins hook for '%s' unexpectedly failed with %d\n",
++					test_cases[i].name,
++					errno);
++				ret = false;
++			}
++		} else {
++			char readback[17] = {0};
++			size_t n = fread(readback, 1, 16, fh);
++			torture_comment(tctx,
++					"wins hook wrote '%s' read '%.*s'\n",
++					test_cases[i].name,
++					(int)n, readback);
++
++			if (! test_cases[i].should_succeed) {
++				torture_comment(tctx,
++						"wins hook for '%s' should fail\n",
++						test_cases[i].name);
++				ret = false;
++			}
++			fclose(fh);
++		}
++	}
++	err = unlink(wins_hook_file);
++	if (err != 0 && errno != ENOENT) {
++		torture_comment(tctx, "final unlink of '%s' failed\n",
++				wins_hook_file);
++	}
++	torture_assert(tctx, ret, "wins hook failure\n");
++	return ret;
++}
++
++
++/*
+   test WINS operations
+ */
+ struct torture_suite *torture_nbt_wins(TALLOC_CTX *mem_ctx)
+@@ -540,6 +668,8 @@ struct torture_suite *torture_nbt_wins(T
+ 	struct torture_suite *suite = torture_suite_create(mem_ctx, "wins");
+ 
+ 	torture_suite_add_simple_test(suite, "wins", nbt_test_wins);
++	torture_suite_add_simple_test(suite, "wins_bad_names",
++				      nbt_test_wins_bad_names);
+ 
+ 	return suite;
+ }
+--- /dev/null
++++ b/testprogs/blackbox/wins_hook_test
+@@ -0,0 +1,15 @@
++#!/usr/bin/python3
++
++import os
++import sys
++
++filename = f"{os.environ['SELFTEST_TMPDIR']}/wins_hook_writes_here"
++
++f = open(filename, 'wb')
++
++# Some names may truncate argv (e.g. '&'), for which we leave the file
++# empty.
++if len(sys.argv) > 2:
++    f.write(os.fsencode(sys.argv[2]))
++
++f.close()

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -29,3 +29,5 @@ add-interface-for-libsmbclient.patch
 fix-smbtree-segfault.patch
 fix-smb-userpass-mount-fail.patch
 fix-statvfs-fail.patch
+CVE-2025-10230-tests.patch
+CVE-2025-10230-fix.patch


### PR DESCRIPTION
This patch fixes a critical security vulnerability (CVE-2025-10230) in the Samba WINS server. The vulnerability allowed unauthenticated clients to execute arbitrary commands on the server by sending malicious NetBIOS names to the WINS server when a "wins hook" script was configured.

The fix adds proper validation to ensure that WINS names contain only allowed characters (letters, digits, hyphens, underscores, and periods) before passing them to the shell command. This matches the behavior described in the smb.conf man page and the existing protection in the source3 nmbd WINS server.

Changes in debian/:
- Add CVE-2025-10230-tests.patch with test cases
- Add CVE-2025-10230-fix.patch with the actual fix
- Update series file to include new patches
- Update changelog with version bump and description

Security impact: High - Remote code execution via command injection

Log: Fixed CVE-2025-10230 WINS hook command injection vulnerability

Influence:
1. Verify WINS hook is not called for names with shell metacharacters
2. Test that valid NetBIOS names still work correctly with wins hook
3. Ensure no regression in WINS server functionality
4. Test on systems with wins hook configured
5. Verify security fix doesn't break existing deployments

fix: 修复 CVE-2025-10230 WINS hook 命令注入漏洞

此补丁修复了 Samba WINS 服务器中的一个严重安全漏洞 (CVE-2025-10230)。
当配置了 "wins hook" 脚本时，该漏洞允许未经身份验证的客户端通过向
WINS 服务器发送恶意 NetBIOS 名称来在服务器上执行任意命令。

修复方案添加了适当的验证，确保 WINS 名称只包含允许的字符（字母、
数字、连字符、下划线和点号），然后再将其传递给 shell 命令。

debian/ 目录变更：
- 添加 CVE-2025-10230-tests.patch 测试用例
- 添加 CVE-2025-10230-fix.patch 修复补丁
- 更新 series 文件包含新补丁
- 更新 changelog 版本和说明

安全影响：高 - 通过命令注入实现远程代码执行

Log: 修复 CVE-2025-10230 WINS hook 命令注入漏洞

Influence:
1. 验证对于包含 shell 元字符的名称不会调用 WINS hook
2. 测试有效的 NetBIOS 名称仍然可以正常使用 wins hook
3. 确保 WINS 服务器功能没有回归
4. 在配置了 wins hook 的系统上进行测试
5. 验证安全修复不会破坏现有部署

repo: samba #master