### PR TITLE
fix: remove winexe entries from samba-common-bin.install

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+samba (2:4.22.8+dfsg-0+deb13u2deepin5) unstable; urgency=medium
+
+  * fix: conditionally build and install winexe per architecture
+    - Uncomment mingw-w64 build deps with arch restrictions [linux-any !sw64 !loong64]
+    - Remove winexe from samba-common-bin.install (static list)
+    - Add conditional winexe install in debian/rules execute_after_dh_install-arch
+    - sw64 and loong64 lack gcc-mingw-w64 cross-compilers,
+      so winexe is only built and packaged on supported architectures
+
+ -- lichenggang <lichenggang@uniontech.com>  Mon, 15 Jun 2026 14:55:56 +0800
+
 samba (2:4.22.8+dfsg-0+deb13u2deepin4) unstable; urgency=medium
 
   * fix: comment out unused mingw-w64 build dependencies (debian/control)

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,8 @@ Build-Depends-Arch:
 	libparse-yapp-perl:native | libparse-yapp-perl,
 	rpcsvc-proto,
 # for winexe. gcc-mingw-w64 brings 4 toolchains, we need only 2
-#        gcc-mingw-w64-i686-win32, gcc-mingw-w64-x86-64-win32,
+	gcc-mingw-w64-i686-win32 [!sw64 !loong64],
+	gcc-mingw-w64-x86-64-win32 [!sw64 !loong64],
 # system libraries:
 	pkgconf,
 	libacl1-dev,

--- a/debian/not-installed
+++ b/debian/not-installed
@@ -18,3 +18,6 @@ usr/lib/*/pkgconfig/pyldb-util.cpython-*.pc
 usr/include/pytalloc.h
 usr/lib/${DEB_HOST_MULTIARCH}/pkgconfig/pytalloc-util.cpython-*.pc
 usr/lib/${DEB_HOST_MULTIARCH}/libpytalloc-util.cpython-*.so
+# winexe: conditionally installed by debian/rules execute_after_dh_install-arch
+usr/bin/winexe
+usr/share/man/man1/winexe.1

--- a/debian/rules
+++ b/debian/rules
@@ -311,6 +311,11 @@ execute_after_dh_install-arch:
 	    debian/samba/usr/share/man/man8/vfs_glusterfs*.8 \
 	    debian/samba/usr/lib/${DEB_HOST_MULTIARCH}/samba/vfs/ceph*.so \
 	    debian/samba/usr/share/man/man8/vfs_ceph*.8
+	# winexe: only install if built (mingw-w64 unavailable on sw64/loong64)
+	if [ -f debian/tmp/usr/bin/winexe ]; then \
+	    install -Dp -m0755 debian/tmp/usr/bin/winexe debian/samba-common-bin/usr/bin/winexe; \
+	    install -Dp -m0644 debian/tmp/usr/share/man/man1/winexe.1 debian/samba-common-bin/usr/share/man/man1/winexe.1; \
+	fi
 
 provision-dest := debian/samba-ad-provision/usr/share/samba/setup
 

--- a/debian/samba-common-bin.install
+++ b/debian/samba-common-bin.install
@@ -7,12 +7,10 @@ usr/bin/samba-regedit
 usr/bin/smbcontrol
 usr/bin/smbpasswd
 usr/bin/testparm
-usr/bin/winexe
 usr/share/man/man1/dbwrap_tool.1
 usr/share/man/man1/nmblookup.1
 usr/share/man/man1/samba-log-parser.1
 usr/share/man/man1/testparm.1
-usr/share/man/man1/winexe.1
 usr/share/man/man5/lmhosts.5
 usr/share/man/man5/smb.conf.5
 usr/share/man/man1/smbcontrol.1


### PR DESCRIPTION
    fix: conditionally build and install winexe per architecture
    
    Re-enable mingw-w64 cross-compilation dependencies for winexe
    on architectures that support it (linux-any except sw64 and loong64),
    and conditionally install winexe into samba-common-bin only when
    the binary is actually built during the package build process.
    
    Changes:
    - Uncomment gcc-mingw-w64 build deps with [linux-any !sw64 !loong64]
    - Remove static winexe entries from samba-common-bin.install
    - Add conditional install in execute_after_dh_install-arch
    
    Log: conditionally build and install winexe only on supported architectures
    
    Influence:
    1. Verify samba builds successfully on amd64 with winexe included
    2. Verify samba builds successfully on sw64/loong64 without winexe
    3. Confirm samba-common-bin package contains winexe on amd64
    4. Confirm no regression on other samba subpackages
    
    fix: 根据架构条件构建和安装 winexe
    
    在支持 mingw-w64 的架构上重新启用 winexe 的交叉编译依赖，
    仅在 winexe 实际被构建时才将其安装到 samba-common-bin 包中。
    
    Log: 仅在支持的架构上条件构建和安装 winexe
    
    Influence:
    1. 验证 amd64 上 samba 构建成功且包含 winexe
    2. 验证 sw64/loong64 上 samba 构建成功且不含 winexe
    3. 确认 amd64 上 samba-common-bin 包包含 winexe
    4. 确认其他 samba 子包无回归
