### PR TITLE
fix(debian): add sw64 and loong64 architecture support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+samba (2:4.22.8+dfsg-0+deb13u2deepin6) unstable; urgency=medium
+
+  * fix(debian): add sw64 and loong64 architecture support
+
+ -- wangrong <wangrong@uniontech.com>  Mon, 22 Jun 2026 17:30:46 +0800
+
 samba (2:4.22.8+dfsg-0+deb13u2deepin5) unstable; urgency=medium
 
   * fix: conditionally build and install winexe per architecture

--- a/debian/control
+++ b/debian/control
@@ -426,7 +426,7 @@ Description: Samba Virtual FileSystem glusterfs modules
 
 Package: libsmbclient0
 # ${t64:Provides}:
-Provides: libsmbclient (= ${binary:Version}) [amd64 arm64 i386 mips64el ppc64el riscv64 s390x]
+Provides: libsmbclient (= ${binary:Version}) [amd64 arm64 i386 mips64el ppc64el riscv64 s390x sw64 loong64]
 Replaces: libsmbclient
 Breaks: libsmbclient (<< ${source:Version})
 Section: libs


### PR DESCRIPTION
## Summary

Add sw64 and loong64 to the Provides field for libsmbclient0 package to support these new CPU architectures.

## Test

- Build verification passed

## Influence

libsmbclient0 包现在支持 sw64 和 loong64 架构，扩大了兼容性范围。

## Related Issue

PMS: BUG-367069