### PR TITLE
fix: fix volume_label crash

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+samba (2:4.22.8+dfsg-0+deb13u2deepin7) unstable; urgency=medium
+
+  * fix: fix volume_label crash
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 24 Jun 2026 17:52:18 +0800
+
 samba (2:4.22.8+dfsg-0+deb13u2deepin6) unstable; urgency=medium
 
   * fix(debian): add sw64 and loong64 architecture support

--- a/debian/patches/fix-volume_label-crash.patch
+++ b/debian/patches/fix-volume_label-crash.patch
@@ -1,0 +1,13 @@
+--- a/source3/param/loadparm.c
++++ b/source3/param/loadparm.c
+@@ -4439,6 +4439,10 @@
+ 		label = lp_servicename(ctx, lp_sub, snum);
+ 	}
+ 
++	if (!label) {
++		return "";
++	}
++
+ 	/*
+ 	 * Volume label can be a max of 32 bytes. Make sure to truncate
+ 	 * it at a codepoint boundary if it's longer than 32 and contains

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -29,3 +29,4 @@ add-interface-for-libsmbclient.patch
 fix-smbtree-segfault.patch
 fix-smb-userpass-mount-fail.patch
 fix-statvfs-fail.patch
+fix-volume_label-crash.patch


### PR DESCRIPTION
coredump:
    max_data_bytes=max_data_bytes@entry=32, fixed_portion=fixed_portion@entry=0x7ffffbac09c0, fsp=fsp@entry=0x5555801cc880, fname=0x5555801c49f0, ppdata=ppdata@entry=0x7ffffbac09b0,
    ret_data_len=ret_data_len@entry=0x7ffffbac0998) at source3/smbd/smb2_trans2.c:1986
    in_info_type=2 '\002', fsp=0x5555801cc880, smb2req=0x5555801e47c0, ev=0x55558019c3d0, mem_ctx=0x5555801e47c0) at source3/smbd/smb2_getinfo.c:478

Log: Fix samba crash